### PR TITLE
Update domain references and location to terraluxe.in/Delhi

### DIFF
--- a/content/privacy-policy.md
+++ b/content/privacy-policy.md
@@ -57,7 +57,7 @@ _Last updated: April 2025_
 
 This Privacy Notice for NexoraTLX ("**we**," "**us**," or "**our**"), describes how and why we might access, collect, store, use, and/or share ("**process**") your personal information when you use our services ("**Services**"), including when you:
 
-*   Visit our website at nexoratlx.com, or any website of ours that links to this Privacy Notice
+*   Visit our website at terraluxe.in, or any website of ours that links to this Privacy Notice
 
 *   Engage with us in other related ways, including any sales, marketing, or events
 
@@ -602,7 +602,7 @@ NexoraTLX
 
 \_\_\_\_\_\_\_\_\_\_
 
-Hyderabad, Telangana
+Delhi, Telangana
 
 India
 

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -16,7 +16,7 @@ export const metadata: Metadata = {
   openGraph: {
     title: 'About | Nexora TLX',
     description: 'Explore latest insights, research articles, and updates on STEAM education with Nexora TLX\'s curated blog posts.',
-    url: 'https://nexoratlx.com/about',
+    url: 'https://terraluxe.in/about',
     siteName: 'Nexora TLX',
     images: [
       {

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -15,7 +15,7 @@ export const metadata: Metadata = {
   openGraph: {
     title: 'Blogs | Nexora TLX',
     description: 'Latest articles and updates on STEAM education from Nexora TLX.',
-    url: 'https://nexoratlx.com/blogs',
+    url: 'https://terraluxe.in/blogs',
     siteName: 'Nexora TLX',
     images: [
       {

--- a/src/app/courses/page.tsx
+++ b/src/app/courses/page.tsx
@@ -9,13 +9,13 @@ import { CourseNavbar } from '@/components/sections/Courses/CourseNavbar';
 import ScrollToTopButton from '@/components/sections/ScrollToTop';
 
 export const metadata: Metadata = {
-  title: 'Blogs | Nexora TLX - Shaping the Future of STEAM Education',
+  title: 'Courses | Nexora TLX - Shaping the Future of STEAM Education',
   description:
     'Explore latest insights, research articles, and updates on STEAM education with Nexora TLX\'s curated blog posts.',
   openGraph: {
     title: 'Blogs | Nexora TLX',
     description: 'Latest articles and updates on STEAM education from Nexora TLX.',
-    url: 'https://nexoratlx.com/blogs',
+    url: 'https://terraluxe.in/courses',
     siteName: 'Nexora TLX',
     images: [
       {

--- a/src/app/resources/config.js
+++ b/src/app/resources/config.js
@@ -1,5 +1,5 @@
 // IMPORTANT: Replace with your own domain address - it&apos;s used for SEO in meta tags and schema
-const baseURL = "https://nexoratlx.com";
+const baseURL = "https://terraluxe.in";
 
 const routes = {
   "/": true,

--- a/src/app/robots.txt/route.ts
+++ b/src/app/robots.txt/route.ts
@@ -1,6 +1,6 @@
 // src/app/robots.txt/route.ts
 
-const baseURL = "https://nexoratlx.com";
+const baseURL = "https://terraluxe.in";
 
 export async function GET() {
   const content = `

--- a/src/app/sitemap.xml/route.ts
+++ b/src/app/sitemap.xml/route.ts
@@ -1,6 +1,6 @@
 // app/sitemap.xml/route.ts
 
-const baseURL = "https://nexoratlx.com";
+const baseURL = "https://terraluxe.in";
 
 const routesConfig = {
   "/": true,

--- a/src/components/sections/ContactSection.tsx
+++ b/src/components/sections/ContactSection.tsx
@@ -28,9 +28,9 @@ const ContactSection = () => {
           icon: <IconMail />,
         },
         {
-          title: "Hyderabad, India",
+          title: "Delhi, India",
           description:
-            "Visit us at our Hyderabad office for personalized assistance.",
+            "Visit us at our Delhi office for personalized assistance.",
           icon: <IconMapPin />,
         },
       ];

--- a/src/components/sections/OurPrograms.tsx
+++ b/src/components/sections/OurPrograms.tsx
@@ -56,12 +56,18 @@ export function Programs() {
             <div className="absolute inset-0 bg-black/50 group-hover:bg-black/70 transition duration-300 z-0" />
 
             {/* Content */}
-            <div id="courses" className="relative z-10 p-6 h-full flex flex-col justify-end">
+            <a
+                id="courses"
+                href="/courses"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="relative z-10 p-6 h-full flex flex-col justify-end"
+            >
                 <h2 className="text-white text-2xl font-bold mb-2">Courses</h2>
                 <p className="text-white text-sm">
                     Explore our comprehensive courses designed to enhance your skills and knowledge.
                 </p>
-            </div>
+            </a>
             </div>
 
             {/* Card4 */}


### PR DESCRIPTION
Replaced all occurrences of 'nexoratlx.com' with 'terraluxe.in' across metadata, config, robots.txt, and sitemap files. Updated location references from Hyderabad to Delhi in the privacy policy and contact section. Fixed metadata titles and URLs for the courses and blog pages, and made the 'Courses' card in OurPrograms a link to the courses page.